### PR TITLE
Add make, libzmq-dev, protobuf-compiler

### DIFF
--- a/pages/docs/client/dev-environment.md
+++ b/pages/docs/client/dev-environment.md
@@ -61,7 +61,7 @@ Bitmask depends on these libraries:
 
 In debian-based systems:
 
-    $ sudo apt-get install git python-dev python-setuptools python-virtualenv python-pip libssl-dev python-openssl libsqlite3-dev g++ openvpn pyside-tools python-pyside libffi-dev
+    $ sudo apt-get install git make python-dev python-setuptools python-virtualenv python-pip libssl-dev python-openssl libsqlite3-dev g++ openvpn pyside-tools python-pyside libffi-dev libzmq-dev protobuf-compiler
 
 
 Working with virtualenv


### PR DESCRIPTION
I add make in the second place because it's near to the level of
abstraction of git.