### PR TITLE
Added section on invite codes to documentation

### DIFF
--- a/pages/docs/platform/services/webapp.md
+++ b/pages/docs/platform/services/webapp.md
@@ -48,6 +48,25 @@ By putting this in `services/webapp.json`, all the `webapp` nodes will inherit t
 
 There are many options in `provider.json` that also control how the webapp behaves. See [[provider-configuration]] for details.
 
+* Invite codes:  Enabling the invite code functionality will require new users to provide a valid invite code while signing up for a new account. This is turned off by default, allowing all new users to create an account. To turn on invite codes, follow these steps after making sure that LEAP webapp and LEAP platform are both v0.8 or greater:
+
+Set the `invite_code` option to `true` in `services/webapp.json`:
+
+    {
+      "webapp": {
+        "invite_required": true
+      }
+    }    
+
+Run `leap deploy` to enable the option.
+
+You can then generate invite codes by running the following rake task from the webapp directory:
+    
+  `sudo -u leap-webapp RAILS_ENV=production bundle exec rake generate_invites[x,y]`
+    
+The *x* specifies the amount of codes to generate. The *y* parameter is optional: By default, all new invite codes can be used once and will then become invalid. If you provide another value for *y*, you can set a different amount of maximum uses for the codes you generate.
+
+
 Customization
 ---------------------------
 


### PR DESCRIPTION
The webapp configuration section now has a section on enabling and generating invite codes.