### PR TITLE
leap_cli depends on nokogiri which depends on zlib1g-dev

### DIFF
--- a/pages/docs/platform/tutorials/quick-start.md
+++ b/pages/docs/platform/tutorials/quick-start.md
@@ -41,11 +41,11 @@ Install core prerequisites on your workstation.
 
 *Debian Unstable (sid)*
 
-    workstation$ sudo apt-get install git rsync openssh-client openssl
+    workstation$ sudo apt-get install git rsync openssh-client openssl zlib1g-dev
 
 *Other Debian & Ubuntu*
 
-    workstation$ sudo apt-get install git ruby ruby-dev rsync openssh-client openssl rake make bzip2
+    workstation$ sudo apt-get install git ruby ruby-dev rsync openssh-client openssl rake make bzip2 zlib1g-dev
 
 *Mac OS*
 


### PR DESCRIPTION
setting up leap_cli on a new debian system i was unable to install using the documented proccess. it was easy to fix and the process worked without issues debian unstable and testing (but i had to manually install ruby and ruby-dev on unstable to install using the gem method even if they are not listed in the sid instructions).