### PR TITLE
[docs] replace download URL with page that bitmask.net uses

### DIFF
--- a/pages/download/en.haml
+++ b/pages/download/en.haml
@@ -4,7 +4,7 @@
   .col-xs-4.text-center
     %i.fa.fa-4x.fa-download
     %div
-      [[Bitmask client application => https://dl.bitmask.net]]<br>
+      [[Bitmask client application => https://bitmask.net/en/install]]<br>
       for end-users.
   .col-xs-4.text-center
     %i.fa.fa-4x.fa-tasks


### PR DESCRIPTION
On https://leap.se/en/download the download link for bitmask client application
is https://dl.bitmask.net/. However, the copyright on this page looks a bit old
(2016), and it's different from the download page presented by bitmask.net,
https://bitmask.net/en/install.

Documentation: #9